### PR TITLE
Use Custom Object Variables to set environment and service

### DIFF
--- a/src/alerta-neb.c
+++ b/src/alerta-neb.c
@@ -305,8 +305,9 @@ check_handler (int event_type, void *data)
 
         host *host_object = host_chk_data->object_ptr;
         customvar = host_object->custom_variables;
+        customvariablesmember *cvar;
 
-        for (customvariablesmember *cvar = customvar; cvar != NULL; cvar = cvar->next) {
+        for (cvar = customvar; cvar != NULL; cvar = cvar->next) {
           if (!strcmp (cvar->variable_name, "ENVIRONMENT")) {
             sprintf (cov_environment, "%s", cvar->variable_value);
           }
@@ -380,8 +381,9 @@ check_handler (int event_type, void *data)
 
           service *service_object = svc_chk_data->object_ptr;
           customvar = service_object->custom_variables;
+          customvariablesmember *cvar;
 
-          for (customvariablesmember *cvar = customvar; cvar != NULL; cvar = cvar->next) {
+          for (cvar = customvar; cvar != NULL; cvar = cvar->next) {
             if (!strcmp (cvar->variable_name, "ENVIRONMENT")) {
               sprintf (cov_environment, "%s", cvar->variable_value);
             }


### PR DESCRIPTION
Use Custom Object Variables named `_Environment` and `_Service` to set the environment and service for an alert on a per-check basis.

See https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/customobjectvars.html

**Alerta-NEB Defaults**
Environment: `Production`
Service: `Platform`

**Global nagios.cfg override**
`broker_module=/usr/lib/nagios/alerta-neb.o http://localhost:8080 debug=1 env=GlobalEnv`

**Per Host / Svc Check setting using Custom Object Variables**
```
define host{
        use                     generic-host            ; Name of host template to use
        host_name               localhost
        alias                   localhost
        address                 127.0.0.1
        _Environment            Development
        _Service                Twitter
        }
```
```
define service{
        use                             generic-service         ; Name of service template to use
        host_name                       localhost
        service_description             Total Processes
        _Environment                    Test
        _Service                        Search
        check_command                   check_procs!250!400
        }
```
